### PR TITLE
[WIP] make work adjustable, add extra tests

### DIFF
--- a/bench/pelemay_fp_bench.exs
+++ b/bench/pelemay_fp_bench.exs
@@ -1,59 +1,106 @@
 defmodule PelemayFpBench do
   use Benchfella
 
-  @list Enum.to_list(1..100000)
+  @list Enum.to_list(1..100_000)
+  @work 1000
 
   setup_all do
     LogisticMap.logistic_map_10_pelemay(@list)
     {:ok, nil}
   end
 
-
   bench "Enum" do
-  	Enum.map(@list, &LogisticMap.logistic_map_10(&1))
+    Enum.map(@list, &LogisticMap.logistic_map_work(&1, @work))
   end
 
   bench "PelemayFp" do
-  	PelemayFp.map(@list, &LogisticMap.logistic_map_10(&1))
+    PelemayFp.map(@list, &LogisticMap.logistic_map_work(&1, @work))
   end
 
   bench "Flow (without sorting)" do
-  	@list
-  	|> Flow.from_enumerable()
-  	|> Flow.map(&LogisticMap.logistic_map_10(&1))
-  	|> Enum.to_list()
-  	:ok
+    @list
+    |> Flow.from_enumerable()
+    |> Flow.map(&LogisticMap.logistic_map_work(&1, @work))
+    |> Enum.to_list()
+
+    :ok
   end
 
   bench "Flow (with sorting)" do
-  	@list
-  	|> Flow.from_enumerable()
-  	|> Flow.map(&LogisticMap.logistic_map_10(&1))
-  	|> Enum.sort()
-  	:ok
+    @list
+    |> Flow.from_enumerable()
+    |> Flow.map(&LogisticMap.logistic_map_work(&1, @work))
+    |> Enum.sort()
+
+    :ok
   end
 
   bench "Pmap" do
-  	Parallel.pmap(@list, &LogisticMap.logistic_map_10(&1))
+    Parallel.pmap(@list, &LogisticMap.logistic_map_work(&1, @work))
   end
 
   bench "Pelemay" do
-  	LogisticMap.logistic_map_10_pelemay(@list)
+    LogisticMap.logistic_map_10_pelemay(@list)
   end
 
   bench "PelemayFp and Pelemay" do
-  	PelemayFp.map_chunk(@list, &LogisticMap.logistic_map_10(&1), &LogisticMap.logistic_map_10_pelemay(&1))
+    PelemayFp.map_chunk(
+      @list,
+      &LogisticMap.logistic_map_work(&1, 10),
+      &LogisticMap.logistic_map_10_pelemay(&1)
+    )
   end
 
   bench "Stream" do
     @list
-    |> Stream.map(&LogisticMap.logistic_map_10(&1))
+    |> Stream.map(&LogisticMap.logistic_map_work(&1, @work))
     |> Stream.run()
   end
 
   bench "Task.async_stream" do
-    @list 
-    |> Task.async_stream(&LogisticMap.logistic_map_10(&1))
+    @list
+    |> Task.async_stream(&LogisticMap.logistic_map_work(&1, @work))
+    |> Enum.to_list()
+  end
+
+  bench "no calculation" do
+    @list
+    |> Enum.map(fn x -> x end)
+  end
+
+  bench "PelemayFp with very small batches" do
+    PelemayFp.map(@list, &LogisticMap.logistic_map_work(&1, @work), 10)
+  end
+
+  bench "PelemayFp with small batches" do
+    PelemayFp.map(@list, &LogisticMap.logistic_map_work(&1, @work), 1000)
+  end
+
+  bench "PelemayFp with big batches" do
+    PelemayFp.map(@list, &LogisticMap.logistic_map_work(&1, @work), 120_000)
+  end
+
+  bench "Task.async_stream in chunks" do
+    @list
+    |> Stream.chunk_every(12000)
+    |> Task.async_stream(fn e -> Enum.map(e, &LogisticMap.logistic_map_work(&1, @work)) end)
+    |> Stream.flat_map(fn {:ok, v} -> v end)
+    |> Enum.to_list()
+  end
+
+  bench "Task.async_stream in big chunks" do
+    @list
+    |> Stream.chunk_every(120_000)
+    |> Task.async_stream(fn e -> Enum.map(e, &LogisticMap.logistic_map_work(&1, @work)) end)
+    |> Stream.flat_map(fn {:ok, v} -> v end)
+    |> Enum.to_list()
+  end
+
+  bench "Task.async_stream in small chunks" do
+    @list
+    |> Stream.chunk_every(1000)
+    |> Task.async_stream(fn e -> Enum.map(e, &LogisticMap.logistic_map_work(&1, @work)) end)
+    |> Stream.flat_map(fn {:ok, v} -> v end)
     |> Enum.to_list()
   end
 end

--- a/lib/pelemay_fp_benchmark/logistic_map.ex
+++ b/lib/pelemay_fp_benchmark/logistic_map.ex
@@ -5,7 +5,7 @@ defmodule LogisticMap do
     rem(22 * v * (v + 1), 6_700_417)
   end
 
-  def logistic_map_10(v) do
+  def logistic_map_work(v, 10) do
     logistic_map(v)
     |> logistic_map()
     |> logistic_map()
@@ -16,6 +16,21 @@ defmodule LogisticMap do
     |> logistic_map()
     |> logistic_map()
     |> logistic_map()
+  end
+
+  def logistic_map_work(v, work) do
+    new_work = div(work, 10)
+
+    logistic_map_work(v, new_work)
+    |> logistic_map_work(new_work)
+    |> logistic_map_work(new_work)
+    |> logistic_map_work(new_work)
+    |> logistic_map_work(new_work)
+    |> logistic_map_work(new_work)
+    |> logistic_map_work(new_work)
+    |> logistic_map_work(new_work)
+    |> logistic_map_work(new_work)
+    |> logistic_map_work(new_work)
   end
 
   defpelemay do


### PR DESCRIPTION
Followup on discussion in https://elixirforum.com/t/pelemay-fast-parallel-map-has-just-been-released/36455/8

This PR is not primarily intended for merging, but for keeping discussion clear (hard to talk about measurements without consistent rulers).

Adds a few useful numbers:

* "no calculation" measures the time taken to traverse `@list` once. This provides a useful order-of-magnitude for comparing different numbers as the size of `@list` is changed.

* "`Task.async_stream` in chunks" uses `Stream.chunk_every` to produce larger pieces of work for each process used in `Task.async_stream`, to amortize the process startup overhead across more elements


The original benchmark doesn't do all that much work per-element, so a `work` parameter is added. Setting it to `10` produces the same results as before (running with 8 schedulers):
```
jones-mbp-sd:pelemay_fp_benchmark mattjones$ elixir --erl "+S 8:8" -S mix bench
Settings:
  duration:      1.0 s

## PelemayFpBench
[18:04:38] 1/13: Enum
[18:04:40] 2/13: Flow (with sorting)
[18:04:43] 3/13: Flow (without sorting)
[18:04:44] 4/13: PelemayFp
[18:04:47] 5/13: PelemayFp with big batches
[18:04:50] 6/13: PelemayFp with small batches
[18:04:52] 7/13: Pmap
[18:04:54] 8/13: Stream
[18:04:57] 9/13: Task.async_stream
[18:05:00] 10/13: Task.async_stream in big chunks
[18:05:02] 11/13: Task.async_stream in chunks
[18:05:04] 12/13: Task.async_stream in small chunks
[18:05:07] 13/13: no calculation

Finished in 31.41 seconds

## PelemayFpBench
benchmark name                     iterations   average time 
no calculation                           1000   2282.81 µs/op
PelemayFp                                 200   9891.31 µs/op
Flow (without sorting)                    100   12020.69 µs/op
PelemayFp with small batches              100   12467.78 µs/op
Task.async_stream in chunks               100   19612.73 µs/op
Task.async_stream in small chunks         100   21763.91 µs/op
Enum                                      100   22796.84 µs/op
PelemayFp with big batches                100   28039.87 µs/op
Stream                                    100   28289.14 µs/op
Task.async_stream in big chunks            50   40396.80 µs/op
Flow (with sorting)                        20   72010.70 µs/op
Pmap                                        5   413570.60 µs/op
Task.async_stream                           2   768808.50 µs/op
```
Only a 2x speedup from 8 CPUs!

Setting it to `1000` shows much better scaling behavior (running with 8 schedulers):
```
jones-mbp-sd:pelemay_fp_benchmark mattjones$ elixir --erl "+S 8:8" -S mix bench
Settings:
  duration:      1.0 s

## PelemayFpBench
[16:48:31] 1/13: Enum
[16:48:33] 2/13: Flow (with sorting)
[16:48:35] 3/13: Flow (without sorting)
[16:48:38] 4/13: PelemayFp
[16:48:40] 5/13: PelemayFp with big batches
[16:48:43] 6/13: PelemayFp with small batches
[16:48:45] 7/13: Pmap
[16:48:48] 8/13: Stream
[16:48:50] 9/13: Task.async_stream
[16:48:52] 10/13: Task.async_stream in big chunks
[16:48:54] 11/13: Task.async_stream in chunks
[16:48:56] 12/13: Task.async_stream in small chunks
[16:48:59] 13/13: no calculation

Finished in 30.46 seconds

## PelemayFpBench
benchmark name                     iterations   average time 
no calculation                           1000   2285.76 µs/op
Flow (without sorting)                      5   377934.80 µs/op
PelemayFp with small batches                5   400980.00 µs/op
Task.async_stream in small chunks           5   418457.40 µs/op
PelemayFp                                   5   426184.80 µs/op
Flow (with sorting)                         5   428551.80 µs/op
Task.async_stream in chunks                 5   452122.20 µs/op
Pmap                                        2   825515.00 µs/op
Task.async_stream                           1   1570360.00 µs/op
Enum                                        1   2020534.00 µs/op
Task.async_stream in big chunks             1   2061052.00 µs/op
Stream                                      1   2161011.00 µs/op
PelemayFp with big batches                  1   2542501.00 µs/op
```
Now 8 CPUs gets a 5x speedup.

The "big batches" number looks bad because a "big batch" is bigger than `@list` with the default settings (120000 elements).